### PR TITLE
Gitprint convert to PDF option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 These are the notes I personally use during workshops when teaching for Software Carpentry. I have one file for each session (morning or afternoon, usually corresponding to one module of the [Software Carpentry lessons](http://software-carpentry.org/lessons.html). Some instructors like teaching directly from the web content, but I like making itemized lists to keep myself on track, hence these crib sheets. YMMV!
 
 **A few things to keep in mind about these crib sheets:**
-* These files are written in Markdown. You may find it useful to convert to a PDF for use in the classroom (I display them on my tablet while I'm teaching). One option for converting is [Pandoc](http://pandoc.org).
+* These files are written in Markdown. You may find it useful to convert to a PDF for use in the classroom (I display them on my tablet while I'm teaching). One option for converting is [Pandoc](http://pandoc.org). 
+* Another very easy method to make PDFs is to use Gitprint. Just change the URL from https://git**hub**.com/(remaining_path), to https://git**print**.com/(remaining_path). However, external links to images don't show up using this method (the link does!)
 * These are notes, so it's necessary to read through the full lessons as well.
 * Each lesson also has great instructor guides for each module (see a [Unix](http://swcarpentry.github.io/shell-novice/instructors.html) example). 
 * These notes closely follow the canonical SWC materials, but have some ideas located in different places.


### PR DESCRIPTION
Using gitprint seems to work very well and is easy enough. External image links just show up as links (they are hot links). Unfortunately the browser plugin that would allow you to automatically change "github.com" to "gitprint.com" probably won't work due to java security issues. You have to manually change the URL.
